### PR TITLE
Fix and update signalR

### DIFF
--- a/forgeSample/Startup.cs
+++ b/forgeSample/Startup.cs
@@ -12,7 +12,9 @@ namespace forgeSample
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc(options => options.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Version_3_0).AddNewtonsoftJson();
-            services.AddSignalR();
+            services.AddSignalR().AddNewtonsoftJsonProtocol(opt=> {
+                opt.PayloadSerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -28,14 +30,14 @@ namespace forgeSample
             }
 
             app.UseRouting();
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+            app.UseHttpsRedirection();
+
             app.UseEndpoints(routes =>
             {
                 routes.MapHub<Controllers.ModelDerivativeHub>("/api/signalr/modelderivative");
             });
-
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
-            app.UseHttpsRedirection();
             app.UseMvc();
         }
     }

--- a/forgeSample/Startup.cs
+++ b/forgeSample/Startup.cs
@@ -11,6 +11,7 @@ namespace forgeSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddCors();
             services.AddMvc(options => options.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Version_3_0).AddNewtonsoftJson();
             services.AddSignalR().AddNewtonsoftJsonProtocol(opt=> {
                 opt.PayloadSerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
@@ -38,6 +39,9 @@ namespace forgeSample
             {
                 routes.MapHub<Controllers.ModelDerivativeHub>("/api/signalr/modelderivative");
             });
+            app.UseCors(options=> 
+                options.WithOrigins(Controllers.OAuthController.GetAppSetting("FORGE_WEBHOOK_URL")).AllowAnyMethod()
+            );
             app.UseMvc();
         }
     }

--- a/forgeSample/forgeSample.csproj
+++ b/forgeSample/forgeSample.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Autodesk.Forge" Version="1.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
   </ItemGroup>
 
 </Project>

--- a/forgeSample/wwwroot/index.html
+++ b/forgeSample/wwwroot/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/style.min.css" type="text/css">
   <script src="https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.min.js"></script>
   <!-- .NET SignalR -->
-  <script src="//unpkg.com/@aspnet/signalr@1.1.4/dist/browser/signalr.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/3.1.7/signalr.min.js"></script>
   <!-- this project files -->
   <link href="css/main.css" rel="stylesheet" />
   <script src="js/PropertyPanel.js"></script>

--- a/forgeSample/wwwroot/index.html
+++ b/forgeSample/wwwroot/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/style.min.css" type="text/css">
   <script src="https://developer.api.autodesk.com/modelderivative/v2/viewers/7.*/viewer3D.min.js"></script>
   <!-- .NET SignalR -->
-  <script src="//unpkg.com/@aspnet/signalr@1.1.0/dist/browser/signalr.min.js"></script>
+  <script src="//unpkg.com/@aspnet/signalr@1.1.4/dist/browser/signalr.min.js"></script>
   <!-- this project files -->
   <link href="css/main.css" rel="stylesheet" />
   <script src="js/PropertyPanel.js"></script>

--- a/forgeSample/wwwroot/js/ForgeTree.js
+++ b/forgeSample/wwwroot/js/ForgeTree.js
@@ -273,7 +273,7 @@ var connectionId;
 
 function startConnection(onReady) {
   if (connection && connection.connectionState) { if (onReady) onReady(); return; }
-  connection = new signalR.HubConnectionBuilder().withUrl("/api/signalr/modelderivative").build();
+  connection = new signalR.HubConnectionBuilder().withUrl("/api/signalr/modelderivative").withAutomaticReconnect().build();
   connection.start()
     .then(function () {
       connection.invoke('getConnectionId')


### PR DESCRIPTION
Enable cors (as mentioned [here](https://docs.microsoft.com/pt-br/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#cross-origin-connections)) and ignored referenceloop (as mentioned [here](https://stackoverflow.com/questions/61399453/calling-clients-others-sendasync-disconnects-recipient)) on Startup.cs:
```
services.AddCors();
services.AddMvc(options => options.EnableEndpointRouting = false).SetCompatibilityVersion(CompatibilityVersion.Version_3_0).AddNewtonsoftJson();
services.AddSignalR().AddNewtonsoftJsonProtocol(opt=> {
    opt.PayloadSerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
});

...

app.UseCors(options=> 
    options.WithOrigins(Controllers.OAuthController.GetAppSetting("FORGE_WEBHOOK_URL")).AllowAnyMethod()
);
```
Package updated, as mentioned [here](https://docs.microsoft.com/pt-br/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#use-a-content-delivery-network-cdn) on index.html:
```
<script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/3.1.7/signalr.min.js"></script>
```
Added package to change to Newtonsoft on signalR on forgeSample.csproj:
```
<PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.10" />
```
A new method for automatic reconnect (mentioned [here](https://docs.microsoft.com/pt-br/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#automatically-reconnect)) from recent version of signalR added on ForgeTree.js:
```
connection = new signalR.HubConnectionBuilder().withUrl("/api/signalr/modelderivative").withAutomaticReconnect().build();
```